### PR TITLE
feat: Add GitHub Actions CI pipeline for Rust project

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,36 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4 # Updated to v4
+    - name: Set up Rust
+      uses: actions/setup-rust@v1 # Or dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+    - name: Cache Cargo dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+    - name: Build for release
+      run: cargo build --release --verbose


### PR DESCRIPTION
This commit introduces a CI pipeline using GitHub Actions.

The workflow (`.github/workflows/rust.yml`) is configured to:
- Trigger on pushes to the `main` branch and pull requests targeting `main`.
- Run on an `ubuntu-latest` runner.
- Set up the stable Rust toolchain.
- Cache Cargo dependencies to speed up subsequent builds.
- Build the project using `cargo build --verbose`.
- Run tests using `cargo test --verbose`.
- Build the project in release mode using `cargo build --release --verbose`.