### PR TITLE
Fix: Improve CSV import, error handling, and add tests

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -12,6 +12,7 @@ pub struct PasswordManagerApp {
     message: String,
     password_length: String,
     initialized: bool,
+    csv_path_input: String,
 }
 
 impl Default for PasswordManagerApp {
@@ -19,6 +20,7 @@ impl Default for PasswordManagerApp {
         Self {
             pm: Arc::new(Mutex::new(Some(PasswordManager::new("passwords.enc")))),
             master_password: String::new(),
+            csv_path_input: String::new(),
             website: String::new(),
             username: String::new(),
             password: String::new(),
@@ -214,7 +216,7 @@ impl PasswordManagerApp {
             if self.message.starts_with("Please enter") {
                 ui.horizontal(|ui| {
                     ui.label(RichText::new("CSV Path:").size(16.0));
-                    ui.text_edit_singleline(&mut self.master_password);
+                    ui.text_edit_singleline(&mut self.csv_path_input);
                 });
                 
                 if ui.button(RichText::new("Load").size(16.0)).clicked() {
@@ -263,18 +265,16 @@ impl PasswordManagerApp {
 
     fn start_import(&mut self) {
         self.message = "Please enter the path to Chrome Passwords.csv".to_string();
-        self.master_password.clear();
+        self.csv_path_input.clear();
     }
 
     fn import_from_csv(&mut self) {
-        let path = std::path::PathBuf::from(&self.master_password);
+        let path = std::path::PathBuf::from(&self.csv_path_input);
         if path.exists() {
             if let Some(pm) = self.pm.lock().unwrap().as_mut() {
-                match pm.import_from_csv(&self.master_password) {
+                match pm.import_from_csv(&self.csv_path_input) {
                     Ok(_) => {
                         self.message = "Passwords imported successfully. Use website URL to retrieve passwords.".to_string();
-                        // Clear the master_password field after successful import
-                        self.master_password.clear();
                     }
                     Err(e) => self.message = format!("Error importing CSV: {}", e),
                 }
@@ -282,5 +282,6 @@ impl PasswordManagerApp {
         } else {
             self.message = "CSV file does not exist".to_string();
         }
+        self.csv_path_input.clear();
     }
 }

--- a/src/password_manager.rs
+++ b/src/password_manager.rs
@@ -32,11 +32,27 @@ pub struct PasswordManager {
 impl PasswordManager {
     pub fn new(file_path: &str) -> Self {
         let password_file = if Path::new(file_path).exists() {
-            let content = fs::read_to_string(file_path).unwrap_or_default();
-            serde_json::from_str(&content).unwrap_or(PasswordFile {
-                salt: vec![],
-                passwords: HashMap::new(),
-            })
+            match fs::read_to_string(file_path) {
+                Ok(content) => {
+                    match serde_json::from_str(&content) {
+                        Ok(pf) => pf,
+                        Err(e) => {
+                            eprintln!("Error parsing password file {}: {}", file_path, e);
+                            PasswordFile {
+                                salt: rand::thread_rng().sample_iter(&Alphanumeric).take(SALT_LENGTH).collect(),
+                                passwords: HashMap::new(),
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Error reading password file {}: {}", file_path, e);
+                    PasswordFile {
+                        salt: rand::thread_rng().sample_iter(&Alphanumeric).take(SALT_LENGTH).collect(),
+                        passwords: HashMap::new(),
+                    }
+                }
+            }
         } else {
             PasswordFile {
                 salt: rand::thread_rng().sample_iter(&Alphanumeric).take(SALT_LENGTH).collect(),
@@ -127,9 +143,24 @@ impl PasswordManager {
         
         for result in rdr.records() {
             let record = result.map_err(|e| anyhow!("Error reading CSV record: {}", e))?;
-            let website = record.get(1).ok_or(anyhow!("Missing URL"))?;
-            let username = record.get(2).ok_or(anyhow!("Missing Username"))?;
-            let password = record.get(3).ok_or(anyhow!("Missing Password"))?;
+            let website = record.get(1).ok_or_else(|| {
+                anyhow!(
+                    "Missing URL (expected at index 1) in CSV record. Record data: {:?}",
+                    record.iter().collect::<Vec<&str>>()
+                )
+            })?;
+            let username = record.get(2).ok_or_else(|| {
+                anyhow!(
+                    "Missing Username (expected at index 2) in CSV record. Record data: {:?}",
+                    record.iter().collect::<Vec<&str>>()
+                )
+            })?;
+            let password = record.get(3).ok_or_else(|| {
+                anyhow!(
+                    "Missing Password (expected at index 3) in CSV record. Record data: {:?}",
+                    record.iter().collect::<Vec<&str>>()
+                )
+            })?;
             
             self.store_password(website, username, password)?;
         }
@@ -141,5 +172,122 @@ impl PasswordManager {
         let content = serde_json::to_string_pretty(&self.password_file)?;
         fs::write(&self.file_path, content)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    // Helper function to clean up files, ignoring errors if the file doesn't exist
+    fn cleanup_file(path: &str) {
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_new_password_manager() {
+        let test_file = "test_passwords_new.enc";
+        cleanup_file(test_file); // Ensure clean state before test
+
+        let pm = PasswordManager::new(test_file);
+        assert!(!pm.password_file.salt.is_empty(), "Salt should be generated for a new password manager.");
+        
+        // The PasswordManager::new creates an empty file if it doesn't exist, or reads it.
+        // If it was newly created, it won't save the salt until a password is stored.
+        // For this test, the salt is in memory. If the file was created, it would be empty.
+        // If we want to test file creation, we should store a password.
+        // However, the requirement is to check `password_file.salt` in memory.
+
+        cleanup_file(test_file);
+    }
+
+    #[test]
+    fn test_store_and_get_password() {
+        let test_file = "test_passwords_store_get.enc";
+        cleanup_file(test_file);
+
+        let mut pm = PasswordManager::new(test_file);
+        pm.initialize("test_master_password").expect("Initialization failed");
+
+        let website = "https://example.com";
+        let username = "testuser";
+        let password = "testpassword123";
+
+        pm.store_password(website, username, password).expect("Storing password failed");
+        
+        let (retrieved_username, retrieved_password) = pm.get_password(website).expect("Getting password failed");
+
+        assert_eq!(retrieved_username, username);
+        assert_eq!(retrieved_password, password);
+
+        cleanup_file(test_file);
+    }
+
+    #[test]
+    fn test_get_non_existent_password() {
+        let test_file = "test_passwords_non_existent.enc";
+        cleanup_file(test_file);
+
+        let mut pm = PasswordManager::new(test_file);
+        pm.initialize("test_master_password").expect("Initialization failed");
+
+        let result = pm.get_password("https://nonexistent.com");
+        assert!(result.is_err(), "Expected an error when getting a non-existent password.");
+
+        cleanup_file(test_file);
+    }
+
+    #[test]
+    fn test_generate_password() {
+        let test_file = "test_passwords_generate.enc"; // Not strictly used, but for consistency
+        cleanup_file(test_file);
+
+        let pm = PasswordManager::new(test_file);
+        let length = 12;
+        let password = pm.generate_password(length);
+        assert_eq!(password.len(), length, "Generated password has incorrect length.");
+
+        // Optional: Check if password contains characters from the defined CHARSET
+        const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()";
+        for char_code in password.as_bytes() {
+            assert!(CHARSET.contains(char_code), "Generated password contains invalid character.");
+        }
+        
+        cleanup_file(test_file); // File might not be created, but cleanup is harmless
+    }
+
+    #[test]
+    fn test_import_from_csv_basic() {
+        let csv_file_path = "test_import_data.csv";
+        let pm_file_path = "test_passwords_import.enc";
+        cleanup_file(csv_file_path);
+        cleanup_file(pm_file_path);
+
+        // Create a temporary CSV file
+        let mut file = fs::File::create(csv_file_path).expect("Failed to create test CSV file");
+        writeln!(file, "name,url,username,password").expect("Write header failed");
+        writeln!(file, "ExampleSite,https://example.com,user1,pass1").expect("Write row 1 failed");
+        writeln!(file, "AnotherSite,https://another.org,user2,pass2").expect("Write row 2 failed");
+        drop(file); // Ensure file is closed
+
+        let mut pm = PasswordManager::new(pm_file_path);
+        pm.initialize("test_master_password").expect("Initialization failed");
+
+        let import_result = pm.import_from_csv(csv_file_path);
+        assert!(import_result.is_ok(), "Import from CSV failed: {:?}", import_result.err());
+
+        // Verify imported passwords
+        let (user1_username, user1_password) = pm.get_password("https://example.com").expect("Failed to get password for example.com");
+        assert_eq!(user1_username, "user1");
+        assert_eq!(user1_password, "pass1");
+
+        let (user2_username, user2_password) = pm.get_password("https://another.org").expect("Failed to get password for another.org");
+        assert_eq!(user2_username, "user2");
+        assert_eq!(user2_password, "pass2");
+        
+        cleanup_file(csv_file_path);
+        cleanup_file(pm_file_path);
     }
 }


### PR DESCRIPTION
This commit introduces several improvements to the password manager:

- **Refactor CSV Import UI (`gui.rs`):**
  - Introduced a dedicated `csv_path_input` field in `PasswordManagerApp` for the CSV file path, replacing the overloaded use of the `master_password` field for this purpose. This improves UI clarity and reduces potential user confusion.

- **Enhance Error Handling (`password_manager.rs`):**
  - Improved `PasswordManager::new()` to more gracefully handle cases where the password file is missing, unreadable, or corrupt. It now prints error messages to stderr and creates a new, valid password file with a fresh salt if an existing one cannot be processed.
  - Made error messages in `PasswordManager::import_from_csv()` more specific. If a CSV record is missing expected fields (URL, username, password), the error now includes details about the missing field and the content of the problematic record, aiding in diagnosing CSV file issues.

- **Add Unit Tests (`password_manager.rs`):**
  - Implemented a suite of unit tests for the `PasswordManager` core logic.
  - Tests cover:
    - Creation of a new password manager instance.
    - Storing and successfully retrieving passwords.
    - Handling attempts to retrieve non-existent passwords.
    - Password generation (length and character set).
    - Basic CSV import functionality.
  - These tests help ensure the reliability and maintainability of the password management core.